### PR TITLE
Move the meetings to be 1 hour earlier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ If you're interested in learning more about our governance or becoming a member 
 
 ## Join the fun!
 
-* We have a [Google Hangouts](https://hangouts.google.com/call/BgkpIXkZghZH92NqjNWsAEEI) meeting every other Wednesday at **19:00 UTC**.
-* [This link](https://www.google.com/search?q=1900+utc+in+local+time) should convert that time to your local time zone's time.
+* We have a [Google Hangouts](https://hangouts.google.com/call/BgkpIXkZghZH92NqjNWsAEEI) meeting every other Wednesday at **18:00 UTC**.
+* [This link](https://www.google.com/search?q=1800+utc+in+local+time) should convert that time to your local time zone's time.
 * If you'd like to use Google Calendar to track meeting days you can follow this event: <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MWgxZnN2cWR2NjBhZGlhODBwNXRoc3RrMDBfMjAxOTA3MTBUMTkwMDAwWiAxM3JhM3R1ZXFrcWJmZnBmMmc1NmZvMmN0c0Bn&amp;tmsrc=13ra3tueqkqbffpf2g56fo2cts%40group.calendar.google.com"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>    
 * We have a `wg-gamedev` channel in the [Offical Rust Discord][discord].
 * There are some additional places to gather and discuss the subject of gamedev


### PR DESCRIPTION
This was requested by @kvark, and also it was seconded by several folks.

The main question here is: Do we want to move the meetings by just one hour, or do we want to also pick some other day entirely?

The meetings will probably get bumped to 1 hour earlier either way so that more European folks can have a chance to join in, and probably not too many more hours earlier than that or the North Americans get zoned out of the process.