### PR TITLE
Remove info about the meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@ If you have an idea, proposal or issue where you think the rust language or ecos
 If you're interested in learning more about our governance or becoming a member you can start [here](GOVERNANCE.md).
 
 ## Join the fun!
-
-* We have a [Google Hangouts](https://hangouts.google.com/call/BgkpIXkZghZH92NqjNWsAEEI) meeting every other Wednesday at **18:00 UTC**.
-  * [This link](https://www.google.com/search?q=1800+utc+in+local+time) should convert that time to your local time zone's time.
-  * If you'd like to use Google Calendar to track meeting days you can follow this event: <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MWgxZnN2cWR2NjBhZGlhODBwNXRoc3RrMDBfMjAxOTA3MTBUMTkwMDAwWiAxM3JhM3R1ZXFrcWJmZnBmMmc1NmZvMmN0c0Bn&amp;tmsrc=13ra3tueqkqbffpf2g56fo2cts%40group.calendar.google.com"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>    
+ 
 * We have a `wg-gamedev` channel in the [Offical Rust Discord][discord].
 * We have a `Rust Gamedev WG` room on [Matrix](https://matrix.to/#/#rust-gamedev-wg:matrix.org)
 * There are some additional places to gather and discuss the subject of gamedev


### PR DESCRIPTION
Fixes https://github.com/rust-gamedev/wg/issues/95 (_"Remove the information about meetings from the readme"_)